### PR TITLE
make liveness and readiness probes configurable

### DIFF
--- a/helm-charts/whitesource-renovate/Chart.yaml
+++ b/helm-charts/whitesource-renovate/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: whitesource-renovate
-version: 3.1.2
-appVersion: 2.5.1
+version: 3.1.3
+appVersion: 2.6.0
 description: Responsive Dependency Automation
 home: https://github.com/whitesource/renovate-on-prem
 sources:

--- a/helm-charts/whitesource-renovate/templates/deployment.yaml
+++ b/helm-charts/whitesource-renovate/templates/deployment.yaml
@@ -121,15 +121,14 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          {{- with .Values.livenessProbe }}
           livenessProbe:
-            initialDelaySeconds: 60
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
           readinessProbe:
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/helm-charts/whitesource-renovate/values.yaml
+++ b/helm-charts/whitesource-renovate/values.yaml
@@ -136,6 +136,25 @@ affinity: {}
 
 podSecurityContext: {}
 
+livenessProbe:
+  initialDelaySeconds: 60
+  httpGet:
+    path: /
+    port: http
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 3
+  successThreshold: 1
+
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 3
+  successThreshold: 1
+
 extraVolumes: []
   # - name: secrets-store-inline
   #   csi:


### PR DESCRIPTION
I've noticed that the Renovate pod gets restarted quite often due to the liveness probe failing, even though the logs seem to indicate Renovate is running properly. This PR makes it possible to configure the liveness and readiness probes for the container for end users. The default values are the same as the ones configured in the deployment, although a bit more verbose to show users which values can be changed.