### PR TITLE
Allow configuration of extra kubernetes manifests

### DIFF
--- a/helm-charts/whitesource-renovate/templates/extra-manifests.yaml
+++ b/helm-charts/whitesource-renovate/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/helm-charts/whitesource-renovate/values.yaml
+++ b/helm-charts/whitesource-renovate/values.yaml
@@ -148,3 +148,12 @@ extraVolumeMounts: []
   # - name: secrets-store-inline
   #   mountPath: "/mnt/secrets-store"
   #   readOnly: true
+
+extraObjects: []
+  #  - apiVersion: v1
+  #    kind: Secret
+  #    metadata:
+  #      name: renovate-env-secrets
+  #    stringData:
+  #      DOCKER_DOCKER_IO_USERNAME: foo
+  #      DOCKER_DOCKER_IO_PASSWORD: bar


### PR DESCRIPTION
Currently you allow users of your chart to configure additional environmnet variables. But when you want to configure ENV vars from secrets, you would have to configure them manually.

To keep it generic and not implement each resource speratly I just added a template for a generic kubernetes manifest. This means, that people can now deploy whatever additional kubernetes manifest they need alogside renovate.