### PR TITLE
docs: fix dead link in helm installation instructions

### DIFF
--- a/docs/installation-helm.md
+++ b/docs/installation-helm.md
@@ -13,5 +13,5 @@ helm repo update
 helm install --generate-name --set renovate.config='\{\"token\":\"...\"\}' renovate-on-prem/whitesource-renovate
 ```
 
-> See the available [values](./helm-charts/whitesource-renvoate/values.yaml) for full configuration and review 
+> See the available [values](../helm-charts/whitesource-renovate/values.yaml) for full configuration and review 
 > configuration guides for [GitHub](./configuration-github.md) and/or [GitLab](./configuration-gitlab.md).


### PR DESCRIPTION
This PR:

- [x] Fixes a dead link in the Helm installation instructions.