### PR TITLE
chore: add 'annotations' to values default

### DIFF
--- a/helm-charts/whitesource-renovate/values.yaml
+++ b/helm-charts/whitesource-renovate/values.yaml
@@ -128,6 +128,8 @@ ingress:
 
 resources: {}
 
+annotations: {}
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
When truing up our helm chart with upstream, noted that `annotations` was missing from the `values.yaml` default config. Add this in to signal to folks that this is there and available. 