### PR TITLE
docs: one sentence per line

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Mend Renovate is distributed via Docker Hub using the namespace [whitesource/ren
 
 ## License
 
-Use of Mend Renovate On-Premises is bound by [Mend's Terms of Service](https://www.mend.io/terms-of-service/). You can request a license key by submitting the form at [https://www.mend.io/free-developer-tools/renovate/on-premises/](https://www.mend.io/free-developer-tools/renovate/on-premises/). License requests are processed semi-manually so please allow up to 3 working days to receive your license key by email.
+Use of Mend Renovate On-Premises is bound by [Mend's Terms of Service](https://www.mend.io/terms-of-service/).
+You can request a license key by submitting the form at [https://www.mend.io/free-developer-tools/renovate/on-premises/](https://www.mend.io/free-developer-tools/renovate/on-premises/).
+License requests are processed semi-manually so please allow up to 3 working days to receive your license key by email.
 
 The documentation and examples in this repository are MIT-licensed.
 

--- a/docs/configuration-github.md
+++ b/docs/configuration-github.md
@@ -35,10 +35,13 @@ The App should also subscribe to the following webhook events:
 
 Description, Homepage, User authorization callback URL, and Setup URL are all unimportant so you may set them to whatever you like.
 
-The Mend Renovate webhook listener binds to port 8080 by default, however it will bind to `process.env.PORT` instead if that is defined. Note: The Mend Renovate image takes care of exposing port 8080 of the container, so if you change this port then you will need to take care of any exposing/mapping of ports yourself. In the [Docker Compose example config](https://github.com/mend/renovate-on-prem/tree/main/examples/), the default port 8080 is used but then mapped to port 80 on the host.
+The Mend Renovate webhook listener binds to port 8080 by default, however it will bind to `process.env.PORT` instead if that is defined.
+Note: The Mend Renovate image takes care of exposing port 8080 of the container, so if you change this port then you will need to take care of any exposing/mapping of ports yourself.
+In the [Docker Compose example config](https://github.com/mend/renovate-on-prem/tree/main/examples/), the default port 8080 is used but then mapped to port 80 on the host.
 
 For the Webhook URL field, point it to `/webhook` on port 80 (or whatever port you mapped to) of the server that you will run Mend Renovate on, e.g. http://1.2.3.4/webhook
-Be sure to enter a webhook secret too. If you don't care about the value, then enter 'renovate' as that is the default secret that the webhook handler process uses.
+Be sure to enter a webhook secret too.
+If you don't care about the value, then enter 'renovate' as that is the default secret that the webhook handler process uses.
 
 You can use the [Renovate icon](https://docs.renovatebot.com/assets/images/logo.png) for the app/bot if you desire.
 

--- a/docs/configuration-gitlab.md
+++ b/docs/configuration-gitlab.md
@@ -1,12 +1,14 @@
 # Mend Renovate Configuration for GitLab
 
-Mend Renovate is available for teams that use GitLab for development. It may be used for self-hosted GitLab instances as well as for repositories hosted on gitlab.com
+Mend Renovate is available for teams that use GitLab for development.
+It may be used for self-hosted GitLab instances as well as for repositories hosted on gitlab.com
 
 ## Mend Renovate features
 
 #### Job scheduler
 
-The Mend Renovate's Docker container contains a built-in job scheduler that defaults to enqueing all repositories once per hour. This saves the need for configuring and monitoring any external `cron` process.
+The Mend Renovate's Docker container contains a built-in job scheduler that defaults to enqueing all repositories once per hour.
+This saves the need for configuring and monitoring any external `cron` process.
 
 #### Webhook handler
 
@@ -23,23 +25,30 @@ Each of the above results in a job being enqueued for the relevant repository, s
 
 #### Priority job queue
 
-Priority-based queuing is essential for providing a responsive experience for bot users. For example, if a user makes an update to the config in an onboarding PR, they ideally want to see the results immediately. By assigning onboarding updates the highest priority in the queue, the bot's update to the onboarding PR can proceed as the very next job, even if many others were in the queue already.
+Priority-based queuing is essential for providing a responsive experience for bot users.
+For example, if a user makes an update to the config in an onboarding PR, they ideally want to see the results immediately.
+By assigning onboarding updates the highest priority in the queue, the bot's update to the onboarding PR can proceed as the very next job, even if many others were in the queue already.
 
-In general, job priority is based on the probability that a user may be "waiting" for the bot to do something. That's why onboarding updates are highest priority, and other high priority updates include merging of Renovate PRs because that very often results in other PRs needing updates or rebasing afterwards.
+In general, job priority is based on the probability that a user may be "waiting" for the bot to do something.
+That's why onboarding updates are highest priority, and other high priority updates include merging of Renovate PRs because that very often results in other PRs needing updates or rebasing afterwards.
 
 ## Mend Renovate Installation and Setup
 
 #### Bot Account creation
 
-You should use a dedicated "bot account" for Renovate. Apart from reducing the chance of conflicts, it is better for teams if the actions they see from Renovate are clearly marked as coming from a dedicated bot account and not from a teammate's account, which could be confusing at times. e.g. did the bot automerge that PR, or did a human do it?
+You should use a dedicated "bot account" for Renovate.
+Apart from reducing the chance of conflicts, it is better for teams if the actions they see from Renovate are clearly marked as coming from a dedicated bot account and not from a teammate's account, which could be confusing at times.
+e.g. did the bot automerge that PR, or did a human do it?
 
-If you are running your own instance of GitLab, it's suggested to name the account "Renovate Bot" with username "renovate-bot". Create this account and then create a Personal Access Token for it with `api`, `read_user` and `write_repository` permissions.
+If you are running your own instance of GitLab, it's suggested to name the account "Renovate Bot" with username "renovate-bot".
+Create this account and then create a Personal Access Token for it with `api`, `read_user` and `write_repository` permissions.
 
 It's best not add this bot account to any repositories yet.
 
 #### Bot Server setup
 
-The server setup for Mend Renovate for GitLab is essentially the same as for GitHub Enterprise, so you can look at those examples. Mend Renovate needs only a low-mid range server with Docker capabilities (e.g. 1 VCPU with 3.75GB of RAM).
+The server setup for Mend Renovate for GitLab is essentially the same as for GitHub Enterprise, so you can look at those examples.
+Mend Renovate needs only a low-mid range server with Docker capabilities (e.g. 1 VCPU with 3.75GB of RAM).
 
 ## Configuration
 
@@ -57,9 +66,10 @@ Mend Renovate requires configuration via environment variables in addition to Re
 
 #### Core Renovate Configuration
 
-"Core" Renovate functionality (i.e. same functionality you'd find in the CLI version or the hosted app) can be configured using environment variables (e.g. `RENOVATE_XXXXXX`) or via a `config.js` file that you mount inside the Mend Renovate container to `/usr/src/app/config.js`. Here are some essentials for Mend Renovate:
+"Core" Renovate functionality (i.e. same functionality you'd find in the CLI version or the hosted app) can be configured using environment variables (e.g. `RENOVATE_XXXXXX`) or via a `config.js` file that you mount inside the Mend Renovate container to `/usr/src/app/config.js`.
+Here are some essentials for Mend Renovate:
 
-**`RENOVATE_PLATFORM`**: Set this to `gitlab`
+**`RENOVATE_PLATFORM`**: Set this to `gitlab`.
 
 **`RENOVATE_ENDPOINT`**: This is the API endpoint for your GitLab host. e.g. like `https://gitlab.company.com/api/v4/`
 
@@ -79,14 +89,18 @@ Set the "Secret Token" to the same value you configured for `WEBHOOK_SECRET` ear
 
 Set Hook triggers for "Push events" and "Merge request events".
 
-Once you a System Hook is added, Renovate's webhook handler will receive events from _all_ repositories. Therefore, Renovate maintains a list of all repositories it has access to and discards events from all others.
+Once you a System Hook is added, Renovate's webhook handler will receive events from _all_ repositories.
+Therefore, Renovate maintains a list of all repositories it has access to and discards events from all others.
 
 ## Testing Mend Renovate
 
-At this point you should be ready to test out Mend Renovate. You probably want to create a test repo before adding Mend Renovate to any "real" ones. To simulate normal conditions, create the repository from a regular account and add a package file.
+At this point you should be ready to test out Mend Renovate.
+You probably want to create a test repo before adding Mend Renovate to any "real" ones.
+To simulate normal conditions, create the repository from a regular account and add a package file.
 
 #### Enabling Renovate
 
 To enable Renovate on your test repository, simply add the bot user you created to the project with "Developer" permissions.
 
-Adding Renovate as a Developer to a repository cause a system hook to be sent to Renovate which in turn enqueues a job for the Renovate Worker. The repository should receive an onboarding PR immediately after.
+Adding Renovate as a Developer to a repository cause a system hook to be sent to Renovate which in turn enqueues a job for the Renovate Worker.
+The repository should receive an onboarding PR immediately after.

--- a/docs/installation-helm.md
+++ b/docs/installation-helm.md
@@ -13,5 +13,4 @@ helm repo update
 helm install --generate-name --set renovate.config='\{\"token\":\"...\"\}' renovate-on-prem/whitesource-renovate
 ```
 
-> See the available [values](../helm-charts/whitesource-renovate/values.yaml) for full configuration and review 
-> configuration guides for [GitHub](./configuration-github.md) and/or [GitLab](./configuration-gitlab.md).
+See the available [values](../helm-charts/whitesource-renovate/values.yaml) for full configuration and review configuration guides for [GitHub](./configuration-github.md) and/or [GitLab](./configuration-gitlab.md).

--- a/helm-charts/whitesource-renovate/README.md
+++ b/helm-charts/whitesource-renovate/README.md
@@ -13,4 +13,4 @@ helm repo update
 helm install --generate-name --set renovate.config='\{\"token\":\"...\"\}' renovate-on-prem/whitesource-renovate
 ```
 
-> See the [docs]([https://github.com/mend/renovate-on-prem/blob/main/helm-charts/whitesource-renovate/values.yaml](https://github.com/mend/renovate-on-prem/tree/main/docs)) for further configuration.
+See the [docs]([https://github.com/mend/renovate-on-prem/blob/main/helm-charts/whitesource-renovate/values.yaml](https://github.com/mend/renovate-on-prem/tree/main/docs)) for further configuration.


### PR DESCRIPTION
## Changes:

- Use one sentence per line pattern for documentation files
- Add a missing full stop to the end of a sentence
- Remove the `>` quote layout in two files

## Context:

Closes #272