### PR TITLE
chore(deps): bump renovate image tag

### DIFF
--- a/helm-charts/whitesource-renovate/Chart.yaml
+++ b/helm-charts/whitesource-renovate/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: whitesource-renovate
-version: 3.1.4
-appVersion: 2.6.0
+version: 3.1.5
+appVersion: 4.3.0
 description: Responsive Dependency Automation
 home: https://github.com/whitesource/renovate-on-prem
 sources:

--- a/helm-charts/whitesource-renovate/values.yaml
+++ b/helm-charts/whitesource-renovate/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: whitesource/renovate
-  tag: 2.6.0
+  tag: 4.3.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
This PR updates the image tag and appVersion to the latest available image for `whitesource/renovate`.