### PR TITLE
fix: make optional configuration values optional

### DIFF
--- a/helm-charts/whitesource-renovate/Chart.yaml
+++ b/helm-charts/whitesource-renovate/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: whitesource-renovate
-version: 3.1.4
+version: 3.1.5
 appVersion: 2.6.0
 description: Responsive Dependency Automation
 home: https://github.com/whitesource/renovate-on-prem

--- a/helm-charts/whitesource-renovate/templates/deployment.yaml
+++ b/helm-charts/whitesource-renovate/templates/deployment.yaml
@@ -61,6 +61,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "whitesource-renovate.secret-name" . }}
                   key: renovateToken
+                  optional: true
             {{- end }}
             {{- if or .Values.renovate.githubAppId .Values.renovate.existingSecret }}
             - name: GITHUB_APP_ID
@@ -68,6 +69,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "whitesource-renovate.secret-name" . }}
                   key: githubAppId
+                  optional: true
             {{- end }}
             {{- if or .Values.renovate.githubAppKey .Values.renovate.existingSecret }}
             - name: GITHUB_APP_KEY
@@ -75,6 +77,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "whitesource-renovate.secret-name" . }}
                   key: githubAppKey
+                  optional: true
             {{- end }}
             {{- if or .Values.renovate.githubComToken .Values.renovate.existingSecret }}
             - name: GITHUB_COM_TOKEN
@@ -82,6 +85,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "whitesource-renovate.secret-name" . }}
                   key: githubComToken
+                  optional: true
             {{- end }}
             {{- if or .Values.renovate.webhookSecret .Values.renovate.existingSecret }}
             - name: WEBHOOK_SECRET
@@ -89,6 +93,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "whitesource-renovate.secret-name" . }}
                   key: webhookSecret
+                  optional: true
             {{- end }}
             {{- if .Values.renovate.schedulerCron }}
             - name: SCHEDULER_CRON
@@ -100,6 +105,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "whitesource-renovate.secret-name" . }}
                   key: pipIndexUrl
+                  optional: true
             {{- end }}
             {{- if .Values.renovate.noNodeTlsVerify }}
             - name: NODE_TLS_REJECT_UNAUTHORIZED


### PR DESCRIPTION
This PR makes configuration values that are not required on all platforms/for all configurations optional.

This is required when using the `existingSecret` to not require values to be set when they are not used.

Resolves #298.
