### PR TITLE
feat: make terminationGracePeriodSeconds configurable

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,0 +1,6 @@
+# See https://github.com/helm/chart-testing/blob/main/doc/ct_lint.md
+target-branch: main
+
+# Turn off maintainer validation since this checks that
+# the mainainer names are valid GitHub usernames
+validate-maintainers: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: Lint charts
+
+on:
+  merge_group:
+  pull_request:
+    paths:
+      - 'helm-charts/**'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
+        with:
+          version: v3.12.2 # renovate: datasource=github-releases depName=helm packageName=helm/helm
+
+      - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
+        with:
+          python-version: "3.10"
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@e8788873172cb653a90ca2e819d79d65a66d4e76 # v2.4.0
+
+      - name: lint charts
+        run: ct lint --config .github/ct.yaml

--- a/helm-charts/whitesource-renovate/Chart.yaml
+++ b/helm-charts/whitesource-renovate/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: whitesource-renovate
-version: 3.1.5
+version: 3.2.0
 appVersion: 2.6.0
 description: Responsive Dependency Automation
 home: https://github.com/whitesource/renovate-on-prem

--- a/helm-charts/whitesource-renovate/templates/deployment.yaml
+++ b/helm-charts/whitesource-renovate/templates/deployment.yaml
@@ -26,8 +26,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      securityContext:
-{{ toYaml .Values.podSecurityContext | indent 8 }}
+      {{- with .Values.podSecurityContext }}
+      securityContext: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm-charts/whitesource-renovate/values.yaml
+++ b/helm-charts/whitesource-renovate/values.yaml
@@ -138,6 +138,9 @@ affinity: {}
 
 podSecurityContext: {}
 
+# This allows renovate to finish running for a repo and then gracefully exit
+terminationGracePeriodSeconds: 60
+
 livenessProbe:
   initialDelaySeconds: 60
   httpGet:

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base",
+    "config:recommended",
     ":pinDigestsDisabled"
   ],
   "packageRules": [{


### PR DESCRIPTION
This contains the following:

- Make `terminationGracePeriodSeconds` configurable
- Improve templating by not including `securityContext` if empty
- Migrate renovate config
- Add helm lint workflow to ensure syntactic correctness of chart